### PR TITLE
Fix errors on Windows

### DIFF
--- a/reanimate.cabal
+++ b/reanimate.cabal
@@ -55,7 +55,7 @@ library
                        JuicyPixels, attoparsec, parallel, diagrams, diagrams-svg,
                        diagrams-core, diagrams-lib, diagrams-contrib,
                        svg-builder, matrices, cubicbezier, palette, websockets,
-                       hashable, fsnotify
+                       hashable, fsnotify, open-browser
 
 Flag server
   Description: Enable rendering server

--- a/reanimate.cabal
+++ b/reanimate.cabal
@@ -50,7 +50,7 @@ library
                       Reanimate.Cache
                       Paths_reanimate
   build-depends:       base >=4.10 && <4.13,
-                       time, text, unix, filepath, process, directory,
+                       time, text, filepath, process, directory,
                        containers, reanimate-svg >= 0.7.0.0, xml, bytestring, lens, linear, mtl, matrix,
                        JuicyPixels, attoparsec, parallel, diagrams, diagrams-svg,
                        diagrams-core, diagrams-lib, diagrams-contrib,

--- a/src/Reanimate/Driver.hs
+++ b/src/Reanimate/Driver.hs
@@ -33,13 +33,13 @@ reanimate animation = do
     ["once"] -> renderSvgs animation
     _ -> withTempDir $ \tmpDir -> do
       url <- getDataFileName "viewer/build/index.html"
-      putStrLn "Opening browser."
+      putStrLn "Opening browser..."
       bSucc <- openBrowser url
       if bSucc
           then putStrLn "Browser opened."
           else hPutStrLn stderr $ "Failed to open browser. Manually visit: " ++ url
       runServerWith "127.0.0.1" 9161 opts $ \pending -> do
-        putStrLn "Server pending."
+        putStrLn "Server pending..."
         prog <- getProgName
         lst <- listDirectory "."
         mbSelf <- findFile ("." : lst) prog
@@ -52,7 +52,7 @@ reanimate animation = do
             slave <- newEmptyMVar
             let handler = modifyMVar_ slave $ \tid -> do
                   sendTextData conn (T.pack "Compiling")
-                  putStrLn "Kill and respawn."
+                  putStrLn "Killing and respawning..."
                   killThread tid
                   tid <- forkIO $ withTempFile ".exe" $ \tmpExecutable -> do
                     ret <- runCmd_ "stack" $ ["ghc", "--"] ++ ghcOptions tmpDir ++ [self, "-o", tmpExecutable]
@@ -74,7 +74,7 @@ reanimate animation = do
                               sendTextData conn frame
                               loop (frame : acc)
                   return tid
-            putStrLn "Found self. Listening."
+            putStrLn "Found self. Listening..."
             stop <- watchFile watch self handler
             putMVar slave =<< forkIO (return ())
             let loop = do

--- a/src/Reanimate/Driver.hs
+++ b/src/Reanimate/Driver.hs
@@ -6,7 +6,7 @@ import           Control.Exception  (finally)
 import           Control.Monad.Fix  (fix)
 import qualified Data.Text          as T
 import           Network.WebSockets
-import           System.Directory   (findExecutable, findFile, listDirectory)
+import           System.Directory   (findFile, listDirectory)
 import           System.Environment (getArgs, getProgName)
 import           System.FilePath
 import           System.FSNotify
@@ -15,10 +15,11 @@ import           System.IO          (BufferMode (..), hPutStrLn, hSetBuffering,
 
 import           Data.Maybe
 import           Paths_reanimate
-import           Reanimate.Misc     (runCmd, runCmdLazy, runCmd_, withTempDir,
+import           Reanimate.Misc     (runCmdLazy, runCmd_, withTempDir,
                                      withTempFile)
 import           Reanimate.Monad    (Animation)
 import           Reanimate.Render   (renderSvgs)
+import           Web.Browser        (openBrowser)
 
 opts = defaultConnectionOptions
   { connectionCompressionOptions = PermessageDeflateCompression defaultPermessageDeflate }
@@ -32,7 +33,11 @@ reanimate animation = do
     ["once"] -> renderSvgs animation
     _ -> withTempDir $ \tmpDir -> do
       url <- getDataFileName "viewer/build/index.html"
-      openBrowser url
+      putStrLn "Opening browser."
+      bSucc <- openBrowser url
+      if bSucc
+          then putStrLn "Browser opened."
+          else hPutStrLn stderr $ "Failed to open browser. Manually visit: " ++ url
       runServerWith "127.0.0.1" 9161 opts $ \pending -> do
         putStrLn "Server pending."
         prog <- getProgName
@@ -86,13 +91,3 @@ ghcOptions :: FilePath -> [String]
 ghcOptions tmpDir =
     ["-rtsopts", "--make", "-threaded", "-O2"] ++
     ["-odir", tmpDir, "-hidir", tmpDir]
-
-openBrowser :: String -> IO ()
-openBrowser url = do
-  xdgOpen <- findExecutable "xdg-open"
-  open <- findExecutable "open"
-  case listToMaybe (catMaybes [xdgOpen, open]) of
-    Nothing ->
-      hPutStrLn stderr $ "Failed to open browser. Manually visit: " ++ url
-    Just prog ->
-      runCmd prog [url]


### PR DESCRIPTION
This PR implements some suggestions from #1, in particular:

- Removing the unused `unix` dependency to get compilation to work
- Depending on the `open-browser` package instead of using custom code, which expands the range of platforms supported (including Windows)

An additional third change has also been implemented, namely rephrasing some info messages; previously some of these messages looked like they were errors, causing the impression that `reanimate` wasn't working.