### PR TITLE
BoundingBox support for circles, ellipses and polylines

### DIFF
--- a/src/Reanimate/Svg/BoundingBox.hs
+++ b/src/Reanimate/Svg/BoundingBox.hs
@@ -91,7 +91,7 @@ svgBoundingPoints t = map (Transform.transformPoint m) $
       let (xnum, ynum) = circ ^. circleCenter
           rnum = circ ^. circleRadius
       in case mapMaybe unpackNumber [xnum, ynum, rnum] of 
-        [x, y, r] -> [V2 (x-r) y, V2 (x+r) y, V2 x (y-r), V2 x (y+r)]
+        [x, y, r] -> [ V2 (x + r * cos angle) (y + r * sin angle) | angle <- [0, pi/10 .. 2 * pi]]
         _  -> []
 
     ellipseBoundingPoints e = 
@@ -99,7 +99,7 @@ svgBoundingPoints t = map (Transform.transformPoint m) $
           xrnum = e ^. ellipseXRadius
           yrnum = e ^. ellipseYRadius
       in case mapMaybe unpackNumber [xnum, ynum, xrnum, yrnum] of 
-        [x,y,xr,yr] -> [V2 (x-xr) y, V2 (x+xr) y, V2 x (y-yr), V2 x (y+yr)]
+        [x,y,xr,yr] -> [V2 (x + xr * cos angle) (y + yr * sin angle) | angle <- [0, pi/10 .. 2 * pi]]
         _ -> []
 
     unpackNumber n =

--- a/src/Reanimate/Svg/BoundingBox.hs
+++ b/src/Reanimate/Svg/BoundingBox.hs
@@ -1,18 +1,20 @@
 module Reanimate.Svg.BoundingBox where
 
-import           Control.Arrow
-import           Control.Lens                 ((^.))
+import           Control.Arrow             ((***))
+import           Control.Lens              ((^.))
 import           Data.List
-import           Graphics.SvgTree             hiding (height, line, path, use,
-                                               width)
-import           Linear.V2                    hiding (angle)
+import           Data.Maybe                (mapMaybe)
+import           Graphics.SvgTree          hiding (height, line, path, use,
+                                            width)
+import           Linear.V2                 hiding (angle)
 import           Linear.Vector
 import           Reanimate.Constants
 import           Reanimate.Svg.LineCommand
-import qualified Reanimate.Transform          as Transform
+import qualified Reanimate.Transform       as Transform
 -- import qualified Geom2D.CubicBezier           as Bezier
 
--- (x,y,w,h)
+-- | Return bounding box of SVG tree.
+--  The four numbers returned are (minimal X-coordinate, minimal Y-coordinate, width, height)
 boundingBox :: Tree -> (Double, Double, Double, Double)
 boundingBox t =
     case svgBoundingPoints t of
@@ -59,9 +61,9 @@ svgBoundingPoints t = map (Transform.transformPoint m) $
       FilterTree{}    -> []
       DefinitionTree{} -> []
       PathTree p      -> linePoints $ toLineCommands (p^.pathDefinition)
-      CircleTree{}    -> error "Bounding box: CircleTree"
-      PolyLineTree{}  -> error "Bounding box: PolyLineTree"
-      EllipseTree{}   -> error "Bounding box: EllipseTree"
+      CircleTree c    -> circleBoundingPoints c
+      PolyLineTree pl -> pl ^. polyLinePoints
+      EllipseTree e   -> ellipseBoundingPoints e
       LineTree line   -> map pointToRPoint [line^.linePoint1, line^.linePoint2]
       RectangleTree rect ->
         case pointToRPoint (rect^.rectUpperLeftCorner) of
@@ -84,3 +86,23 @@ svgBoundingPoints t = map (Transform.transformPoint m) $
       case mapTuple (toUserUnit defaultDPI) p of
         (Num x, Num y) -> V2 x y
         _ -> error "Reanimate.Svg.svgBoundingPoints: Unrecognized number format."
+
+    circleBoundingPoints circ = 
+      let (xnum, ynum) = circ ^. circleCenter
+          rnum = circ ^. circleRadius
+      in case mapMaybe unpackNumber [xnum, ynum, rnum] of 
+        [x, y, r] -> [V2 (x-r) y, V2 (x+r) y, V2 x (y-r), V2 x (y+r)]
+        _  -> []
+
+    ellipseBoundingPoints e = 
+      let (xnum,ynum) = e ^. ellipseCenter
+          xrnum = e ^. ellipseXRadius
+          yrnum = e ^. ellipseYRadius
+      in case mapMaybe unpackNumber [xnum, ynum, xrnum, yrnum] of 
+        [x,y,xr,yr] -> [V2 (x-xr) y, V2 (x+xr) y, V2 x (y-yr), V2 x (y+yr)]
+        _ -> []
+
+    unpackNumber n =
+      case toUserUnit defaultDPI n of
+        Num d -> Just d
+        _     -> Nothing


### PR DESCRIPTION
Missing implementation of bounding box for circle just bit me.
I made this simplistic implementation and then realized it doesn't survive under transformations by rotation as illustrated by this gif.
![peek](https://user-images.githubusercontent.com/2716069/73975997-afc99f80-4927-11ea-8e2a-40a0f4f65a69.gif)


I'll do some research into how to do this better. Please don't merge yet.

---

Edit: second commit is attempt at improvement by sampling 20 points on the circle / ellipse instead of just 4. Gives better results at the price of worse computational complexity. Let me know what you think or if you have a better idea how to implement this.

![boundingbox](https://user-images.githubusercontent.com/2716069/73977470-bc9bc280-492a-11ea-9678-a655281c3bb9.gif)
